### PR TITLE
debug

### DIFF
--- a/js/bootstrap-datetimepicker.js
+++ b/js/bootstrap-datetimepicker.js
@@ -109,7 +109,10 @@
     this.initialDate = options.initialDate || new Date();
     this.zIndex = options.zIndex || this.element.data('z-index') || undefined;
     this.title = typeof options.title === 'undefined' ? false : options.title;
-    this.defaultTimeZone = (new Date).toString().split('(')[1].slice(0, -1);
+    var dataStringArray =(new Date).toString().split('(');
+    if(dataStringArray.length==2){    	
+	    this.defaultTimeZone = (new Date).toString().split('(')[1].slice(0, -1);
+    }
     this.timezone = options.timezone || this.defaultTimeZone;
 
     this.icons = {


### PR DESCRIPTION
```
In firefox,(new Date).toString() will only return time.
Like this:"Wed Jul 20 2016 10:27:40 GMT+0800".
modeifed js/bootstrap-datetimepocjer.js line 112.
>this.defaultTimeZone = (newDate).toString().split('(')[1].slice(0, -1);
```
